### PR TITLE
feat(server): add IP access control via --allow-ips / --deny-ips

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ clap = { version = "4.5.51", features = ["derive"] }
 colored = "3.0.0"
 http-body-util = "0.1.3"
 ignore = "0.4.25"
+ipnet = "2.11"
 local-ip-address = "0.6.5"
 maud = "0.27.0"
 mime_guess = "2.0.5"

--- a/src/banner/mod.rs
+++ b/src/banner/mod.rs
@@ -15,6 +15,8 @@ pub fn show_banner(banner_context: BannerContext) {
     let total_size = human_size(banner_context.total_size);
     let show_qr = banner_context.show_qrcode;
     let local_only = banner_context.local_only;
+    let allow_ips = &banner_context.allow_ips;
+    let deny_ips = &banner_context.deny_ips;
     let lan_ip = local_ip().unwrap_or(addr.ip());
 
     println!();
@@ -44,6 +46,28 @@ pub fn show_banner(banner_context: BannerContext) {
     );
     if !local_only {
         println!("{} http://{}:{}", label("🌐 Address:"), lan_ip, addr.port());
+    }
+    if !allow_ips.is_empty() {
+        println!(
+            "{} {}",
+            label("✅ Allow IPs:"),
+            allow_ips
+                .iter()
+                .map(|rule| rule.to_string())
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+    }
+    if !deny_ips.is_empty() {
+        println!(
+            "{} {}",
+            label("⛔ Deny IPs:"),
+            deny_ips
+                .iter()
+                .map(|rule| rule.to_string())
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
     }
 
     if show_qr && !local_only {

--- a/src/cli/context.rs
+++ b/src/cli/context.rs
@@ -1,3 +1,4 @@
+use ipnet::IpNet;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 
@@ -6,6 +7,8 @@ pub struct ServerContext {
     pub addr: SocketAddr,
     pub base_dir: PathBuf,
     pub files: Vec<PathBuf>,
+    pub allow_ips: Vec<IpNet>,
+    pub deny_ips: Vec<IpNet>,
 }
 
 #[derive(Debug)]
@@ -17,4 +20,6 @@ pub struct BannerContext {
     pub total_size: u64,
     pub local_only: bool,
     pub show_qrcode: bool,
+    pub allow_ips: Vec<IpNet>,
+    pub deny_ips: Vec<IpNet>,
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -4,6 +4,7 @@ use crate::matcher::Matcher;
 use clap::Parser;
 use colored::Colorize;
 pub use context::{BannerContext, ServerContext};
+use ipnet::IpNet;
 use std::fs::{self, read_dir};
 use std::net::SocketAddr;
 use std::{
@@ -52,6 +53,22 @@ pub struct Args {
 
     #[arg(long, help = "generate qr code in banner")]
     show_qrcode: bool,
+
+    #[arg(
+        long,
+        value_delimiter = ',',
+        value_parser = clap::value_parser!(IpNet),
+        help = "comma-separated list of allowed IPs/CIDRs"
+    )]
+    allow_ips: Vec<IpNet>,
+
+    #[arg(
+        long,
+        value_delimiter = ',',
+        value_parser = clap::value_parser!(IpNet),
+        help = "comma-separated list of blocked IPs/CIDRs"
+    )]
+    deny_ips: Vec<IpNet>,
 }
 
 fn get_files(path: &Path, files: &mut Vec<PathBuf>, matcher: &Matcher) {
@@ -120,6 +137,8 @@ pub fn parse() -> (BannerContext, ServerContext) {
         false => SocketAddr::from(([0, 0, 0, 0], port)),
     };
     let show_qrcode = args.show_qrcode;
+    let allow_ips = args.allow_ips;
+    let deny_ips = args.deny_ips;
 
     (
         BannerContext {
@@ -130,11 +149,15 @@ pub fn parse() -> (BannerContext, ServerContext) {
             total_size,
             local_only,
             show_qrcode,
+            allow_ips: allow_ips.clone(),
+            deny_ips: deny_ips.clone(),
         },
         ServerContext {
             base_dir,
             files,
             addr,
+            allow_ips,
+            deny_ips,
         },
     )
 }

--- a/src/server/handler.rs
+++ b/src/server/handler.rs
@@ -2,6 +2,7 @@ use super::{state::AppState, style::inline_css, util::file_icon};
 use crate::util::human_size;
 use axum::Json;
 use axum::body::Body;
+use axum::extract::ConnectInfo;
 use axum::extract::Path as AxumPath;
 use axum::extract::State as AxumState;
 use axum::http::{StatusCode, header};
@@ -9,6 +10,7 @@ use axum::response::{Html, IntoResponse, Response};
 use maud::{Markup, html};
 use mime_guess::from_path;
 use serde_json::json;
+use std::net::SocketAddr;
 use std::path::PathBuf;
 use tokio_util::io::ReaderStream;
 use urlencoding::encode;
@@ -58,9 +60,14 @@ pub async fn list_files(AxumState(app_state): AxumState<AppState>) -> impl IntoR
 }
 
 pub async fn download_file(
+    ConnectInfo(remote_addr): ConnectInfo<SocketAddr>,
     AxumState(app_state): AxumState<AppState>,
     AxumPath(path): AxumPath<String>,
 ) -> impl IntoResponse {
+    if !app_state.is_ip_allowed(remote_addr.ip()) {
+        return (StatusCode::FORBIDDEN, "Forbidden").into_response();
+    }
+
     if !app_state.path_set.contains(&path) {
         return (StatusCode::NOT_FOUND, "File not found".to_string()).into_response();
     }

--- a/src/server/handler.rs
+++ b/src/server/handler.rs
@@ -15,7 +15,14 @@ use std::path::PathBuf;
 use tokio_util::io::ReaderStream;
 use urlencoding::encode;
 
-pub async fn index_page(AxumState(state): AxumState<AppState>) -> impl IntoResponse {
+pub async fn index_page(
+    ConnectInfo(remote_addr): ConnectInfo<SocketAddr>,
+    AxumState(state): AxumState<AppState>,
+) -> impl IntoResponse {
+    if !state.is_ip_allowed(remote_addr.ip()) {
+        return (StatusCode::FORBIDDEN, "Forbidden").into_response();
+    }
+
     let files = &state.path_set;
     let meta_data = &state.meta_data;
 
@@ -52,11 +59,18 @@ pub async fn index_page(AxumState(state): AxumState<AppState>) -> impl IntoRespo
         }
     };
 
-    Html(markup.into_string())
+    Html(markup.into_string()).into_response()
 }
 
-pub async fn list_files(AxumState(app_state): AxumState<AppState>) -> impl IntoResponse {
-    Json(json!(app_state.path_set))
+pub async fn list_files(
+    ConnectInfo(remote_addr): ConnectInfo<SocketAddr>,
+    AxumState(app_state): AxumState<AppState>,
+) -> impl IntoResponse {
+    if !app_state.is_ip_allowed(remote_addr.ip()) {
+        return (StatusCode::FORBIDDEN, "Forbidden").into_response();
+    }
+
+    Json(json!(app_state.path_set)).into_response()
 }
 
 pub async fn download_file(

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -8,7 +8,7 @@ use crate::cli::{BannerContext, ServerContext};
 use axum::{Router, routing::get};
 use colored::{self, Colorize};
 use state::AppState;
-use std::{io::Error, process::exit};
+use std::{io::Error, net::SocketAddr, process::exit};
 use tokio::net::TcpListener;
 use tower_http::trace::{DefaultMakeSpan, DefaultOnRequest, DefaultOnResponse, TraceLayer};
 use tracing::Level;
@@ -51,7 +51,10 @@ pub async fn start(
 
     show_banner(banner_context);
 
-    axum::serve(listener, app)
-        .with_graceful_shutdown(shutdown_signal())
-        .await
+    axum::serve(
+        listener,
+        app.into_make_service_with_connect_info::<SocketAddr>(),
+    )
+    .with_graceful_shutdown(shutdown_signal())
+    .await
 }

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -1,7 +1,9 @@
 use crate::cli::ServerContext;
+use ipnet::IpNet;
 use pathdiff::diff_paths;
 use std::collections::{HashMap, HashSet};
 use std::fs::Metadata;
+use std::net::IpAddr;
 use std::path::PathBuf;
 
 #[derive(Debug, Clone)]
@@ -9,6 +11,22 @@ pub struct AppState {
     pub base_dir: PathBuf,
     pub path_set: HashSet<String>,
     pub meta_data: HashMap<String, Metadata>,
+    pub allow_ips: Vec<IpNet>,
+    pub deny_ips: Vec<IpNet>,
+}
+
+impl AppState {
+    pub fn is_ip_allowed(&self, ip: IpAddr) -> bool {
+        if !self.deny_ips.is_empty() && self.deny_ips.iter().any(|rule| rule.contains(&ip)) {
+            return false;
+        }
+
+        if self.allow_ips.is_empty() {
+            return true;
+        }
+
+        self.allow_ips.iter().any(|rule| rule.contains(&ip))
+    }
 }
 
 impl From<ServerContext> for AppState {
@@ -19,8 +37,8 @@ impl From<ServerContext> for AppState {
         for file_path in &server_context.files {
             let relative_path: PathBuf = diff_paths(file_path, &server_context.base_dir).unwrap();
             let path = relative_path.display().to_string().replace("\\", "/");
-            if file_path.metadata().is_ok() {
-                meta_data.insert(path.clone(), file_path.metadata().unwrap());
+            if let Ok(metadata) = file_path.metadata() {
+                meta_data.insert(path.clone(), metadata);
                 path_set.insert(path);
             }
         }
@@ -29,6 +47,8 @@ impl From<ServerContext> for AppState {
             base_dir: server_context.base_dir,
             path_set,
             meta_data,
+            allow_ips: server_context.allow_ips,
+            deny_ips: server_context.deny_ips,
         }
     }
 }


### PR DESCRIPTION
## Scope

- Add `--allow-ips` and `--deny-ips` CLI options supporting comma-separated
  IPs / CIDR notation (e.g., `192.168.1.0/24`)
- Enforce access rules in the file download handler:
  - deny‑list match → `403 Forbidden`
  - allow‑list present with no match → `403 Forbidden`
  - no rules → allow all (current default)
- Surface active rules in the startup banner for easy verification

## Implementation

- New CLI flags parsed with `clap::value_parser!(IpNet)`
- `ipnet` crate for CIDR matching
- Client IP extracted via `axum::extract::ConnectInfo<SocketAddr>`
- `AppState::is_ip_allowed()` encapsulates the allow/deny logic

## Testing

- `cargo check`
- `cargo clippy --all-targets --all-features`
- `cargo fmt`

## Notes

- This PR does not change existing file-serving behavior when no IP
  rules are provided
- The startup banner displays `Allow IPs` / `Deny IPs` only when
  the corresponding lists are non‑empty